### PR TITLE
When SP metadata contains SAML 1.0 profile

### DIFF
--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -96,7 +96,8 @@ module SamlIdp
         "//md:SPSSODescriptor/md:AssertionConsumerService",
         md: metadata_namespace
       ).sort_by { |el| el["index"].to_i }.reduce([]) do |array, el|
-        props = el["Binding"].to_s.match /urn:oasis:names:tc:SAML:(?<version>\S+):bindings:(?<name>\S+)/
+        props = el["Binding"].to_s.match /urn:oasis:names:tc:SAML:(?<version>\S+):(bindings|profiles):(?<name>\S+)/
+        next if props[:version] == '1.0'
         array << { binding: props[:name], location: el["Location"], default: !!el["isDefault"] }
         array
       end

--- a/spec/lib/saml_idp/incoming_metadata_spec.rb
+++ b/spec/lib/saml_idp/incoming_metadata_spec.rb
@@ -22,21 +22,60 @@ module SamlIdp
 </md:EntityDescriptor>
   eos
 
+  metadata_saml1 = <<-eos
+<?xml version="1.0"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2019-04-07T08:23:29Z" cacheDuration="PT604800S" entityID="test">
+    <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test/logout" />
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test/acs" index="0" />
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://test/acs" index="1"/>
+    </md:SPSSODescriptor>
+</md:EntityDescriptor>
+  eos
+
   describe IncomingMetadata do
-    it 'should properly set sign_assertions to false' do
-      metadata = SamlIdp::IncomingMetadata.new(metadata_1)
-      expect(metadata.sign_assertions).to eq(false)
-      expect(metadata.entity_id).to be_a(String)
+    let(:test_metadata) {}
+    subject { SamlIdp::IncomingMetadata.new(test_metadata) }
+
+    context 'false sign_assertions' do
+      let(:test_metadata) { metadata_1 }
+
+      it 'should properly set sign_assertions to false' do
+        expect(subject.sign_assertions).to eq(false)
+      end
     end
 
-    it 'should properly set sign_assertions to true' do
-      metadata = SamlIdp::IncomingMetadata.new(metadata_2)
-      expect(metadata.sign_assertions).to eq(true)
+    context 'true sign_assertions' do
+      let(:test_metadata) { metadata_2 }
+
+      it 'should properly set sign_assertions to true' do
+        expect(subject.sign_assertions).to eq(true)
+      end
     end
 
-    it 'should properly set sign_assertions to false when WantAssertionsSigned is not included' do
-      metadata = SamlIdp::IncomingMetadata.new(metadata_3)
-      expect(metadata.sign_assertions).to eq(false)
+    context 'no sign_assertions' do
+      let(:test_metadata) { metadata_3 }
+
+      it 'should properly set sign_assertions to false when WantAssertionsSigned is not included' do
+        expect(subject.sign_assertions).to eq(false)
+      end
+    end
+
+    context 'entity_id' do
+      let(:test_metadata) { metadata_1 }
+
+      it 'should extract entity id as string' do
+        expect(subject.entity_id).to be_a(String)
+      end
+    end
+
+    context 'acs' do
+      let(:test_metadata) { metadata_saml1 }
+
+      it 'should ignore saml 1.0 attributes' do
+        expect { subject.assertion_consumer_services }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
If metadata binding AssertionConsumerService contain SAML 1 attribute like follows xml parser will throw errors. Instead of throwing error we can ignore it.

    1. urn:oasis:names:tc:SAML:1.0:profiles:browser-post

Of course, I could see there is another solution which is proper parser handler given broken metadata. But, this will be more common case.