### PR TITLE
Fixed: NameID format version issue#3

### DIFF
--- a/lib/saml_idp/name_id_formatter.rb
+++ b/lib/saml_idp/name_id_formatter.rb
@@ -21,8 +21,15 @@ module SamlIdp
         version, choose = "2.0", "persistent" unless choose
         build(version, choose)
       else
-        choose = list.first || "persistent"
-        build("2.0", choose)
+        choose = list.first || ["persistent"]
+        version = case choose.first.to_s.underscore
+                  when 'email_address'
+                    '1.1'
+                  else
+                    '2.0'
+                  end
+
+        build(version, choose)
       end
     end
 


### PR DESCRIPTION
If SP metadata file contains NameID format to be
`urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`

in Assertion it is sending:
`urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`

Resulting in Saml Assertion failure on SP side. ie - Qiita teams, Zoho