### PR TITLE
Adding required gem for response encryption

### DIFF
--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -47,6 +47,7 @@ section of the README.
   s.add_dependency('uuid', '>= 2.3')
   s.add_dependency('builder', '>= 3.0')
   s.add_dependency('nokogiri', '>= 1.6.2')
+  s.add_dependency('xmlenc', '>= 0.7.1')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('simplecov')


### PR DESCRIPTION
When we start to use encrypted response gem start to use xmlenc gem, but when use bundle with rbenv or rvm it gem won't install that Rails environment's gem.