### PR TITLE
Metadata doesn't contain POST url

### DIFF
--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -13,6 +13,7 @@ module SamlIdp
     attr_accessor :reference_id_generator
     attr_accessor :attribute_service_location
     attr_accessor :single_service_post_location
+    attr_accessor :single_service_redirect_location
     attr_accessor :single_logout_service_post_location
     attr_accessor :single_logout_service_redirect_location
     attr_accessor :attributes

--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -29,6 +29,19 @@ module SamlIdp
     end
     hashable :sign_assertions
 
+    def sign_authn_request
+      doc = xpath(
+        "//md:SPSSODescriptor",
+        ds: signature_namespace,
+        md: metadata_namespace
+      ).first
+      if (doc && !doc['AuthnRequestsSigned'].nil?)
+        return doc['AuthnRequestsSigned'].strip.downcase == 'true'
+      end
+      return false
+    end
+    hashable :sign_authn_request
+
     def display_name
       role_descriptor_document.present? ? role_descriptor_document["ServiceDisplayName"] : ""
     end

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -29,8 +29,10 @@ module SamlIdp
               descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
                 Location: single_logout_service_redirect_location
               build_name_id_formats descriptor
-              descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+              descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
                 Location: single_service_post_location
+              descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                Location: single_service_redirect_location
               build_attribute descriptor
             end
 
@@ -151,6 +153,7 @@ module SamlIdp
       organization_url
       attribute_service_location
       single_service_post_location
+      single_service_redirect_location
       single_logout_service_post_location
       single_logout_service_redirect_location
       technical_contact

--- a/lib/saml_idp/persisted_metadata.rb
+++ b/lib/saml_idp/persisted_metadata.rb
@@ -6,5 +6,9 @@ module SamlIdp
     def sign_assertions?
       !!attributes[:sign_assertions]
     end
+
+    def sign_authn_request?
+      !!attributes[:sign_authn_request]
+    end
   end
 end

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -114,9 +114,14 @@ module SamlIdp
     end
 
     def valid_signature?
-      # Force signatures for logout requests because there is no other
-      # protection against a cross-site DoS.
-      service_provider.valid_signature?(document, logout_request?)
+      # Force signatures for logout requests because there is no other protection against a cross-site DoS.
+      # Validate signature when metadata specify AuthnRequest should be signed
+      metadata = service_provider.current_metadata
+      if logout_request? || authn_request? && metadata.respond_to?(:sign_authn_request?) && metadata.sign_authn_request?
+        document.valid_signature?(service_provider.fingerprint)
+      else
+        true
+      end
     end
 
     def service_provider?

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -22,16 +22,11 @@ module SamlIdp
     end
 
     def valid_signature?(doc, require_signature = false)
-      if require_signature || should_validate_signature?
+      if require_signature || attributes[:validate_signature]
         doc.valid_signature?(fingerprint)
       else
         true
       end
-    end
-
-    def should_validate_signature?
-      attributes[:validate_signature] ||
-        current_metadata.respond_to?(:sign_assertions?) && current_metadata.sign_assertions?
     end
 
     def refresh_metadata

--- a/spec/lib/saml_idp/configurator_spec.rb
+++ b/spec/lib/saml_idp/configurator_spec.rb
@@ -9,6 +9,7 @@ module SamlIdp
     it { should respond_to :base_saml_location }
     it { should respond_to :reference_id_generator }
     it { should respond_to :attribute_service_location }
+    it { should respond_to :single_service_redirect_location }
     it { should respond_to :single_service_post_location }
     it { should respond_to :single_logout_service_post_location }
     it { should respond_to :single_logout_service_redirect_location }

--- a/spec/lib/saml_idp/incoming_metadata_spec.rb
+++ b/spec/lib/saml_idp/incoming_metadata_spec.rb
@@ -3,7 +3,7 @@ module SamlIdp
 
   metadata_1 = <<-eos
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="test" entityID="https://test-saml.com/saml">
-  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true" WantAssertionsSigned="false">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="false" WantAssertionsSigned="false">
   </md:SPSSODescriptor>
 </md:EntityDescriptor>
   eos
@@ -22,20 +22,34 @@ module SamlIdp
 </md:EntityDescriptor>
   eos
 
+  metadata_4 = <<-eos
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="test" entityID="https://test-saml.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>
+  eos
+
   describe IncomingMetadata do
     it 'should properly set sign_assertions to false' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_1)
       expect(metadata.sign_assertions).to eq(false)
+      expect(metadata.sign_authn_request).to eq(false)
     end
 
     it 'should properly set sign_assertions to true' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_2)
       expect(metadata.sign_assertions).to eq(true)
+      expect(metadata.sign_authn_request).to eq(true)
     end
 
     it 'should properly set sign_assertions to false when WantAssertionsSigned is not included' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_3)
       expect(metadata.sign_assertions).to eq(false)
+    end
+
+    it 'should properly set sign_authn_request to false when AuthnRequestsSigned is not included' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_4)
+      expect(metadata.sign_authn_request).to eq(false)
     end
   end
 end


### PR DESCRIPTION
1. IdP metadata not providing an SSO url with POST binding.
2. AuthnRequest validation bug. When SP metadata contain AuthnRequestsSigned true then we need to validate AuthnRequest from SP.