### PR TITLE
Allow raw (unsigned) assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /Gemfile.lock
 /gemfiles/*.gemfile.lock
 /.byebug_history
+
+_config\.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - gemfile: gemfiles/rails_dev.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_3.2.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_4.2.gemfile
 before_install:
   # https://docs.travis-ci.com/user/languages/ruby/#bundler
   - RUBY_VERSION=$(ruby -v | grep -o -E '[0-9]\.[0-9]' | tr -d '.')

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ end
 
 #### Singed assertions and Signed Response
 
-By default SAML Assertion will be signed with an algorithm which defined to `config.algorithm`. Because SAML assertions contain secure information used for authentication such as NameID.
+By default SAML Assertion will be signed with an algorithm which defined to `config.algorithm`, because SAML assertions contain secure information used for authentication such as NameID.
+Besides that, signing assertions could be optional and can be defined with `config.signed_assertion` option. Setting this configuration flag to `false` will add raw assertions on the response instead of signed ones. If the response is encrypted the `config.signed_assertion` will be ignored and all assertions will be signed.
 
 Signing SAML Response is optional, but some security perspective SP services might require Response message itself must be signed.
 For that, you can enable it with `config.signed_message` option. [More about SAML spec](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf#page=68)
@@ -118,6 +119,7 @@ CERT
   # config.single_service_post_location = "#{base}/saml/auth"
   # config.session_expiry = 86400                                 # Default: 0 which means never
   # config.signed_message = true                                  # Default: false which means unsigned SAML Response
+  # config.signed_assertion = false                               # Default: true which means signed  assertions on the SAML Response
 
   # Principal (e.g. User) is passed in when you `encode_response`
   #

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ CERT
   # config.single_service_post_location = "#{base}/saml/auth"
   # config.session_expiry = 86400                                 # Default: 0 which means never
   # config.signed_message = true                                  # Default: false which means unsigned SAML Response
-  # config.signed_assertion = false                               # Default: true which means signed  assertions on the SAML Response
+  # config.non_signed_assertion = true                            # Default: false which means signed  assertions on the SAML Response
 
   # Principal (e.g. User) is passed in when you `encode_response`
   #

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-architect

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-midnight

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-architect
+theme: jekyll-theme-midnight

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -62,6 +62,7 @@ module SamlIdp
       expiry = opts[:expiry] || 60*60
       session_expiry = opts[:session_expiry]
       encryption_opts = opts[:encryption] || nil
+      signed_message_opts = opts[:signed_message] || false
 
       SamlResponse.new(
         reference_id,
@@ -75,7 +76,8 @@ module SamlIdp
         my_authn_context_classref,
         expiry,
         encryption_opts,
-        session_expiry
+        session_expiry,
+        signed_message_opts
       ).build
     end
 

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -65,6 +65,7 @@ module SamlIdp
       session_expiry = opts[:session_expiry]
       encryption_opts = opts[:encryption] || nil
       signed_message_opts = opts[:signed_message] || false
+      signed_assertion_opts = opts[:signed_assertion] || true
 
       SamlResponse.new(
         reference_id,
@@ -79,7 +80,8 @@ module SamlIdp
         expiry,
         encryption_opts,
         session_expiry,
-        signed_message_opts
+        signed_message_opts,
+        signed_assertion_opts
       ).build
     end
 

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -65,7 +65,7 @@ module SamlIdp
       session_expiry = opts[:session_expiry]
       encryption_opts = opts[:encryption] || nil
       signed_message_opts = opts[:signed_message] || false
-      signed_assertion_opts = opts[:signed_assertion] || true
+      non_signed_assertion_opts = opts[:non_signed_assertion] || false
 
       SamlResponse.new(
         reference_id,
@@ -81,7 +81,7 @@ module SamlIdp
         encryption_opts,
         session_expiry,
         signed_message_opts,
-        signed_assertion_opts
+        non_signed_assertion_opts
       ).build
     end
 

--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -16,6 +16,11 @@ module SamlIdp
       @document ||= Saml::XML::Document.parse raw
     end
 
+    def entity_id
+      xpath('//md:EntityDescriptor/@entityID', md: metadata_namespace).first.try(:content).to_s
+    end
+    hashable :entity_id
+
     def sign_assertions
       doc = xpath(
         "//md:SPSSODescriptor",

--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -16,6 +16,11 @@ module SamlIdp
       @document ||= Saml::XML::Document.parse raw
     end
 
+    def entity_id
+      xpath('//md:EntityDescriptor/@entityID').first
+    end
+    hashable :entity_id
+
     def sign_assertions
       doc = xpath(
         "//md:SPSSODescriptor",

--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -16,11 +16,6 @@ module SamlIdp
       @document ||= Saml::XML::Document.parse raw
     end
 
-    def entity_id
-      xpath('//md:EntityDescriptor/@entityID').first
-    end
-    hashable :entity_id
-
     def sign_assertions
       doc = xpath(
         "//md:SPSSODescriptor",

--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -16,6 +16,11 @@ module SamlIdp
       @document ||= Saml::XML::Document.parse raw
     end
 
+    def entity_id
+      xpath('//md:EntityDescriptor/@entityID').first.try(:content).to_s
+    end
+    hashable :entity_id
+
     def sign_assertions
       doc = xpath(
         "//md:SPSSODescriptor",

--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -16,11 +16,6 @@ module SamlIdp
       @document ||= Saml::XML::Document.parse raw
     end
 
-    def entity_id
-      xpath('//md:EntityDescriptor/@entityID', md: metadata_namespace).first.try(:content).to_s
-    end
-    hashable :entity_id
-
     def sign_assertions
       doc = xpath(
         "//md:SPSSODescriptor",

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -106,6 +106,7 @@ module SamlIdp
       end
 
       if !service_provider.acceptable_response_hosts.include?(response_host)
+        log "#{service_provider.acceptable_response_hosts} compare to #{response_host}"
         log "No acceptable AssertionConsumerServiceURL, either configure them via config.service_provider.response_hosts or match to your metadata_url host"
         return false
       end

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -1,32 +1,41 @@
 require 'builder'
+require 'saml_idp/signable'
 module SamlIdp
   class ResponseBuilder
+    include Signable
     attr_accessor :response_id
     attr_accessor :issuer_uri
     attr_accessor :saml_acs_url
     attr_accessor :saml_request_id
     attr_accessor :assertion_and_signature
+    attr_accessor :algorithm
 
-    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature)
+    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, algorithm)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_acs_url = saml_acs_url
       self.saml_request_id = saml_request_id
       self.assertion_and_signature = assertion_and_signature
+      self.algorithm = algorithm
     end
 
-    def encoded
-      @encoded ||= encode
+    def encoded(signed_message: false)
+      @encoded ||= signed_message ? encode_signed_message : encode_raw_message
     end
 
     def raw
       build
     end
 
-    def encode
+    def encode_raw_message
       Base64.strict_encode64(raw)
     end
-    private :encode
+    private :encode_raw_message
+
+    def encode_signed_message
+      Base64.strict_encode64(signed)
+    end
+    private :encode_signed_message
 
     def build
       resp_options = {}
@@ -41,6 +50,7 @@ module SamlIdp
       builder = Builder::XmlMarkup.new
       builder.tag! "samlp:Response", resp_options do |response|
           response.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
+          sign response
           response.tag! "samlp:Status" do |status|
             status.tag! "samlp:StatusCode", Value: Saml::XML::Namespaces::Statuses::SUCCESS
           end

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -1,24 +1,22 @@
 require 'builder'
-require 'saml_idp/algorithmable'
 require 'saml_idp/signable'
 module SamlIdp
   class ResponseBuilder
-    include Algorithmable
     include Signable
     attr_accessor :response_id
     attr_accessor :issuer_uri
     attr_accessor :saml_acs_url
     attr_accessor :saml_request_id
     attr_accessor :assertion_and_signature
-    attr_accessor :raw_algorithm
+    attr_accessor :algorithm
 
-    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, raw_algorithm)
+    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, algorithm)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_acs_url = saml_acs_url
       self.saml_request_id = saml_request_id
       self.assertion_and_signature = assertion_and_signature
-      self.raw_algorithm = raw_algorithm
+      self.algorithm = algorithm
     end
 
     def encoded(signed_message: false)

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -62,6 +62,7 @@ module SamlIdp
     def response_id_string
       "_#{response_id}"
     end
+    alias_method :reference_id, :response_id
     private :response_id_string
 
     def now_iso

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -1,22 +1,24 @@
 require 'builder'
+require 'saml_idp/algorithmable'
 require 'saml_idp/signable'
 module SamlIdp
   class ResponseBuilder
+    include Algorithmable
     include Signable
     attr_accessor :response_id
     attr_accessor :issuer_uri
     attr_accessor :saml_acs_url
     attr_accessor :saml_request_id
     attr_accessor :assertion_and_signature
-    attr_accessor :algorithm
+    attr_accessor :raw_algorithm
 
-    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, algorithm)
+    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, raw_algorithm)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_acs_url = saml_acs_url
       self.saml_request_id = saml_request_id
       self.assertion_and_signature = assertion_and_signature
-      self.algorithm = algorithm
+      self.raw_algorithm = raw_algorithm
     end
 
     def encoded(signed_message: false)

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -70,7 +70,7 @@ module SamlIdp
         response_builder.encoded(signed_message: false)
       end
     end
-    private :signed_assertion
+    private :encoded_message
 
     def response_builder
       ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion, algorithm)

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -17,6 +17,7 @@ module SamlIdp
     attr_accessor :expiry
     attr_accessor :encryption_opts
     attr_accessor :session_expiry
+    attr_accessor :signed_message_opts
 
     def initialize(reference_id,
           response_id,
@@ -29,7 +30,8 @@ module SamlIdp
           authn_context_classref,
           expiry=60*60,
           encryption_opts=nil,
-          session_expiry=0
+          session_expiry=0,
+          signed_message_opts
           )
       self.reference_id = reference_id
       self.response_id = response_id
@@ -45,10 +47,11 @@ module SamlIdp
       self.expiry = expiry
       self.encryption_opts = encryption_opts
       self.session_expiry = session_expiry
+      self.signed_message_opts = signed_message_opts
     end
 
     def build
-      @built ||= response_builder.encoded
+      @built ||= encoded_message
     end
 
     def signed_assertion
@@ -60,8 +63,17 @@ module SamlIdp
     end
     private :signed_assertion
 
+    def encoded_message
+      if signed_message_opts
+        response_builder.encoded(signed_message: true)
+      else
+        response_builder.encoded(signed_message: false)
+      end
+    end
+    private :signed_assertion
+
     def response_builder
-      ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion)
+      ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion, algorithm)
     end
     private :response_builder
 

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -70,7 +70,7 @@ module SamlIdp
         response_builder.encoded(signed_message: false)
       end
     end
-    private :encoded_message
+    private :signed_assertion
 
     def response_builder
       ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion, algorithm)

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -2,7 +2,6 @@ require 'saml_idp/assertion_builder'
 require 'saml_idp/response_builder'
 module SamlIdp
   class SamlResponse
-    attr_accessor :assertion_with_signature
     attr_accessor :reference_id
     attr_accessor :response_id
     attr_accessor :issuer_uri
@@ -18,6 +17,7 @@ module SamlIdp
     attr_accessor :encryption_opts
     attr_accessor :session_expiry
     attr_accessor :signed_message_opts
+    attr_accessor :signed_assertion_opts
 
     def initialize(reference_id,
           response_id,
@@ -31,7 +31,8 @@ module SamlIdp
           expiry=60*60,
           encryption_opts=nil,
           session_expiry=0,
-          signed_message_opts
+          signed_message_opts=false,
+          signed_assertion_opts=true
           )
       self.reference_id = reference_id
       self.response_id = response_id
@@ -48,6 +49,7 @@ module SamlIdp
       self.encryption_opts = encryption_opts
       self.session_expiry = session_expiry
       self.signed_message_opts = signed_message_opts
+      self.signed_assertion_opts = signed_assertion_opts
     end
 
     def build
@@ -57,8 +59,10 @@ module SamlIdp
     def signed_assertion
       if encryption_opts
         assertion_builder.encrypt(sign: true)
-      else
+      elsif signed_assertion_opts
         assertion_builder.signed
+      else
+        assertion_builder.raw
       end
     end
     private :signed_assertion

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -17,7 +17,7 @@ module SamlIdp
     attr_accessor :encryption_opts
     attr_accessor :session_expiry
     attr_accessor :signed_message_opts
-    attr_accessor :signed_assertion_opts
+    attr_accessor :non_signed_assertion_opts
 
     def initialize(reference_id,
           response_id,
@@ -32,7 +32,7 @@ module SamlIdp
           encryption_opts=nil,
           session_expiry=0,
           signed_message_opts=false,
-          signed_assertion_opts=true
+          non_signed_assertion_opts=false
           )
       self.reference_id = reference_id
       self.response_id = response_id
@@ -49,7 +49,7 @@ module SamlIdp
       self.encryption_opts = encryption_opts
       self.session_expiry = session_expiry
       self.signed_message_opts = signed_message_opts
-      self.signed_assertion_opts = signed_assertion_opts
+      self.non_signed_assertion_opts = non_signed_assertion_opts
     end
 
     def build
@@ -59,10 +59,10 @@ module SamlIdp
     def signed_assertion
       if encryption_opts
         assertion_builder.encrypt(sign: true)
-      elsif signed_assertion_opts
-        assertion_builder.signed
-      else
+      elsif non_signed_assertion_opts
         assertion_builder.raw
+      else
+        assertion_builder.signed
       end
     end
     private :signed_assertion

--- a/lib/saml_idp/signable.rb
+++ b/lib/saml_idp/signable.rb
@@ -108,8 +108,7 @@ module SamlIdp
       canon_algorithm = Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
       canon_hashed_element = noko_raw.canonicalize(canon_algorithm, inclusive_namespaces)
       digest_algorithm = get_algorithm
-
-      hash                          = digest_algorithm.digest(canon_hashed_element)
+      hash = digest_algorithm.digest(canon_hashed_element)
       Base64.strict_encode64(hash).gsub(/\n/, '')
     end
     private :digest

--- a/lib/saml_idp/signable.rb
+++ b/lib/saml_idp/signable.rb
@@ -108,7 +108,8 @@ module SamlIdp
       canon_algorithm = Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
       canon_hashed_element = noko_raw.canonicalize(canon_algorithm, inclusive_namespaces)
       digest_algorithm = get_algorithm
-      hash = digest_algorithm.digest(canon_hashed_element)
+
+      hash                          = digest_algorithm.digest(canon_hashed_element)
       Base64.strict_encode64(hash).gsub(/\n/, '')
     end
     private :digest

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -47,6 +47,7 @@ section of the README.
   s.add_dependency('uuid', '>= 2.3')
   s.add_dependency('builder', '>= 3.0')
   s.add_dependency('nokogiri', '>= 1.6.2')
+  s.add_dependency('xmlenc', '>= 0.7.1')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('simplecov')

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -58,5 +58,5 @@ section of the README.
   s.add_development_dependency('timecop', '>= 0.8')
   s.add_development_dependency('xmlenc', '>= 0.6.4')
   s.add_development_dependency('appraisal')
+  s.add_development_dependency('byebug')
 end
-

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -58,5 +58,5 @@ section of the README.
   s.add_development_dependency('timecop', '>= 0.8')
   s.add_development_dependency('xmlenc', '>= 0.6.4')
   s.add_development_dependency('appraisal')
-  s.add_development_dependency('byebug')
 end
+

--- a/spec/lib/saml_idp/incoming_metadata_spec.rb
+++ b/spec/lib/saml_idp/incoming_metadata_spec.rb
@@ -26,7 +26,6 @@ module SamlIdp
     it 'should properly set sign_assertions to false' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_1)
       expect(metadata.sign_assertions).to eq(false)
-      expect(metadata.entity_id).to be_a(String)
     end
 
     it 'should properly set sign_assertions to true' do

--- a/spec/lib/saml_idp/incoming_metadata_spec.rb
+++ b/spec/lib/saml_idp/incoming_metadata_spec.rb
@@ -26,6 +26,7 @@ module SamlIdp
     it 'should properly set sign_assertions to false' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_1)
       expect(metadata.sign_assertions).to eq(false)
+      expect(metadata.entity_id).to be_a(String)
     end
 
     it 'should properly set sign_assertions to true' do

--- a/spec/lib/saml_idp/response_builder_spec.rb
+++ b/spec/lib/saml_idp/response_builder_spec.rb
@@ -6,12 +6,14 @@ module SamlIdp
     let(:saml_acs_url) { "http://sportngin.com" }
     let(:saml_request_id) { "134" }
     let(:assertion_and_signature) { "<Assertion xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_abc\" IssueInstant=\"2013-07-31T05:00:00Z\" Version=\"2.0\"><Issuer>http://sportngin.com</Issuer><signature>stuff</signature><Subject><NameID Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">jon.phenow@sportngin.com</NameID><SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><SubjectConfirmationData InResponseTo=\"123\" NotOnOrAfter=\"2013-07-31T05:03:00Z\" Recipient=\"http://saml.acs.url\"/></SubjectConfirmation></Subject><Conditions NotBefore=\"2013-07-31T04:59:55Z\" NotOnOrAfter=\"2013-07-31T06:00:00Z\"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name=\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\"><AttributeValue>jon.phenow@sportngin.com</AttributeValue></Attribute></AttributeStatement><AuthnStatment AuthnInstant=\"2013-07-31T05:00:00Z\" SessionIndex=\"_abc\"><AuthnContext><AuthnContextClassRef>urn:federation:authentication:windows</AuthnContextClassRef></AuthnContext></AuthnStatment></Assertion>" }
+    let(:algorithm) { :sha256 }
     subject { described_class.new(
       response_id,
       issuer_uri,
       saml_acs_url,
       saml_request_id,
-      assertion_and_signature
+      assertion_and_signature,
+      algorithm
     ) }
 
     before do

--- a/spec/lib/saml_idp/response_builder_spec.rb
+++ b/spec/lib/saml_idp/response_builder_spec.rb
@@ -6,14 +6,12 @@ module SamlIdp
     let(:saml_acs_url) { "http://sportngin.com" }
     let(:saml_request_id) { "134" }
     let(:assertion_and_signature) { "<Assertion xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_abc\" IssueInstant=\"2013-07-31T05:00:00Z\" Version=\"2.0\"><Issuer>http://sportngin.com</Issuer><signature>stuff</signature><Subject><NameID Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">jon.phenow@sportngin.com</NameID><SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><SubjectConfirmationData InResponseTo=\"123\" NotOnOrAfter=\"2013-07-31T05:03:00Z\" Recipient=\"http://saml.acs.url\"/></SubjectConfirmation></Subject><Conditions NotBefore=\"2013-07-31T04:59:55Z\" NotOnOrAfter=\"2013-07-31T06:00:00Z\"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name=\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\"><AttributeValue>jon.phenow@sportngin.com</AttributeValue></Attribute></AttributeStatement><AuthnStatment AuthnInstant=\"2013-07-31T05:00:00Z\" SessionIndex=\"_abc\"><AuthnContext><AuthnContextClassRef>urn:federation:authentication:windows</AuthnContextClassRef></AuthnContext></AuthnStatment></Assertion>" }
-    let(:algorithm) { :sha256 }
     subject { described_class.new(
       response_id,
       issuer_uri,
       saml_acs_url,
       saml_request_id,
-      assertion_and_signature,
-      algorithm
+      assertion_and_signature
     ) }
 
     before do

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -26,6 +26,7 @@ module SamlIdp
     end
     let(:signed_response_opts) { true }
     let(:unsigned_response_opts) { false }
+    let(:signed_assertion_opts) { true }
     let(:subject_encrypted) { described_class.new(reference_id,
                                   response_id,
                                   issuer_uri,
@@ -38,7 +39,8 @@ module SamlIdp
                                   expiry,
                                   encryption_opts,
                                   session_expiry,
-                                  unsigned_response_opts
+                                  unsigned_response_opts,
+                                  signed_assertion_opts
                                  )
     }
 
@@ -54,7 +56,8 @@ module SamlIdp
                                   expiry,
                                   nil,
                                   session_expiry,
-                                  signed_response_opts
+                                  signed_response_opts,
+                                  signed_assertion_opts
                                  )
     }
 
@@ -70,34 +73,86 @@ module SamlIdp
       expect(subject.build).to be_present
     end
 
-    it "builds encrypted" do
-      expect(subject_encrypted.build).to_not match(audience_uri)
-      encoded_xml = subject_encrypted.build
-      resp_settings = saml_settings(saml_acs_url)
-      resp_settings.private_key = Default::SECRET_KEY
-      resp_settings.issuer = audience_uri
-      saml_resp = OneLogin::RubySaml::Response.new(encoded_xml, settings: resp_settings)
-      saml_resp.soft = false
-      expect(saml_resp.is_valid?).to eq(true)
+    context "encrypted" do
+      it "builds encrypted" do
+        expect(subject_encrypted.build).to_not match(audience_uri)
+        encoded_xml = subject_encrypted.build
+        resp_settings = saml_settings(saml_acs_url)
+        resp_settings.private_key = Default::SECRET_KEY
+        resp_settings.issuer = audience_uri
+        saml_resp = OneLogin::RubySaml::Response.new(encoded_xml, settings: resp_settings)
+        saml_resp.soft = false
+        expect(saml_resp.is_valid?).to eq(true)
+      end
     end
 
-    it "will build signed valid response" do
-      expect { subject.build }.not_to raise_error
-      signed_encoded_xml = subject.build
-      resp_settings = saml_settings(saml_acs_url)
-      resp_settings.private_key = Default::SECRET_KEY
-      resp_settings.issuer = audience_uri
-      saml_resp = OneLogin::RubySaml::Response.new(signed_encoded_xml, settings: resp_settings)
-      expect(
-        Nokogiri::XML(saml_resp.response).at_xpath(
-        "//p:Response//ds:Signature",
-        {
-          "p" => "urn:oasis:names:tc:SAML:2.0:protocol",
-          "ds" => "http://www.w3.org/2000/09/xmldsig#"
-        }
-      )).to be_present
-      expect(saml_resp.send(:validate_signature)).to eq(true)
-      expect(saml_resp.is_valid?).to eq(true)
+    context "signed response" do
+      let(:resp_settings) do
+        resp_settings = saml_settings(saml_acs_url)
+        resp_settings.private_key = Default::SECRET_KEY
+        resp_settings.issuer = audience_uri
+        resp_settings
+      end
+
+      it "will build signed valid response" do
+        expect { subject.build }.not_to raise_error
+        signed_encoded_xml = subject.build
+        saml_resp = OneLogin::RubySaml::Response.new(signed_encoded_xml, settings: resp_settings)
+        expect(
+          Nokogiri::XML(saml_resp.response).at_xpath(
+          "//p:Response//ds:Signature",
+          {
+            "p" => "urn:oasis:names:tc:SAML:2.0:protocol",
+            "ds" => "http://www.w3.org/2000/09/xmldsig#"
+          }
+        )).to be_present
+        expect(saml_resp.send(:validate_signature)).to eq(true)
+        expect(saml_resp.is_valid?).to eq(true)
+      end
+
+      context "when signed_assertion_opts is true" do
+        it "builds a signed assertion" do
+          expect { subject.build }.not_to raise_error
+          signed_encoded_xml = subject.build
+          saml_resp = OneLogin::RubySaml::Response.new(signed_encoded_xml, settings: resp_settings)
+          expect(
+            Nokogiri::XML(saml_resp.response).at_xpath(
+            "//p:Response//a:Assertion//ds:Signature",
+            {
+              "p" => "urn:oasis:names:tc:SAML:2.0:protocol",
+              "a" => "urn:oasis:names:tc:SAML:2.0:assertion",
+              "ds" => "http://www.w3.org/2000/09/xmldsig#"
+            }
+          )).to be_present
+        end
+      end
+
+      context "when signed_assertion_opts is false" do
+        let(:signed_assertion_opts) { false }
+
+        it "builds a raw assertion" do
+          expect { subject.build }.not_to raise_error
+          signed_encoded_xml = subject.build
+          saml_resp = OneLogin::RubySaml::Response.new(signed_encoded_xml, settings: resp_settings)
+          expect(
+            Nokogiri::XML(saml_resp.response).at_xpath(
+            "//p:Response//a:Assertion",
+            {
+              "p" => "urn:oasis:names:tc:SAML:2.0:protocol",
+              "a" => "urn:oasis:names:tc:SAML:2.0:assertion"
+            }
+          )).to be_present
+
+          expect(
+            Nokogiri::XML(saml_resp.response).at_xpath(
+            "//p:Response//Assertion//ds:Signature",
+            {
+              "p" => "urn:oasis:names:tc:SAML:2.0:protocol",
+              "ds" => "http://www.w3.org/2000/09/xmldsig#"
+            }
+          )).to_not be_present
+        end
+      end
     end
 
     it "sets session expiration" do

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -81,6 +81,25 @@ module SamlIdp
       expect(saml_resp.is_valid?).to eq(true)
     end
 
+    it "will build signed valid response" do
+      expect { subject.build }.not_to raise_error
+      signed_encoded_xml = subject.build
+      resp_settings = saml_settings(saml_acs_url)
+      resp_settings.private_key = Default::SECRET_KEY
+      resp_settings.issuer = audience_uri
+      saml_resp = OneLogin::RubySaml::Response.new(signed_encoded_xml, settings: resp_settings)
+      expect(
+        Nokogiri::XML(saml_resp.response).at_xpath(
+        "//p:Response//ds:Signature",
+        {
+          "p" => "urn:oasis:names:tc:SAML:2.0:protocol",
+          "ds" => "http://www.w3.org/2000/09/xmldsig#"
+        }
+      )).to be_present
+      expect(saml_resp.send(:validate_signature)).to eq(true)
+      expect(saml_resp.is_valid?).to eq(true)
+    end
+
     it "sets session expiration" do
       saml_resp = OneLogin::RubySaml::Response.new(subject.build)
       expect(saml_resp.session_expires_at).to eq Time.local(1990, "jan", 2).iso8601

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -24,6 +24,8 @@ module SamlIdp
         key_transport: 'rsa-oaep-mgf1p',
       }
     end
+    let(:signed_response_opts) { true }
+    let(:unsigned_response_opts) { false }
     let(:subject_encrypted) { described_class.new(reference_id,
                                   response_id,
                                   issuer_uri,
@@ -35,7 +37,8 @@ module SamlIdp
                                   authn_context_classref,
                                   expiry,
                                   encryption_opts,
-                                  session_expiry
+                                  session_expiry,
+                                  unsigned_response_opts
                                  )
     }
 
@@ -50,7 +53,8 @@ module SamlIdp
                                   authn_context_classref,
                                   expiry,
                                   nil,
-                                  session_expiry
+                                  session_expiry,
+                                  signed_response_opts
                                  )
     }
 

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -24,8 +24,6 @@ module SamlIdp
         key_transport: 'rsa-oaep-mgf1p',
       }
     end
-    let(:signed_response_opts) { true }
-    let(:unsigned_response_opts) { false }
     let(:subject_encrypted) { described_class.new(reference_id,
                                   response_id,
                                   issuer_uri,
@@ -37,8 +35,7 @@ module SamlIdp
                                   authn_context_classref,
                                   expiry,
                                   encryption_opts,
-                                  session_expiry,
-                                  unsigned_response_opts
+                                  session_expiry
                                  )
     }
 
@@ -53,8 +50,7 @@ module SamlIdp
                                   authn_context_classref,
                                   expiry,
                                   nil,
-                                  session_expiry,
-                                  signed_response_opts
+                                  session_expiry
                                  )
     }
 

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -26,7 +26,7 @@ module SamlIdp
     end
     let(:signed_response_opts) { true }
     let(:unsigned_response_opts) { false }
-    let(:signed_assertion_opts) { true }
+    let(:non_signed_assertion_opts) { false }
     let(:subject_encrypted) { described_class.new(reference_id,
                                   response_id,
                                   issuer_uri,
@@ -40,7 +40,7 @@ module SamlIdp
                                   encryption_opts,
                                   session_expiry,
                                   unsigned_response_opts,
-                                  signed_assertion_opts
+                                  non_signed_assertion_opts
                                  )
     }
 
@@ -57,7 +57,7 @@ module SamlIdp
                                   nil,
                                   session_expiry,
                                   signed_response_opts,
-                                  signed_assertion_opts
+                                  non_signed_assertion_opts
                                  )
     }
 
@@ -110,7 +110,7 @@ module SamlIdp
         expect(saml_resp.is_valid?).to eq(true)
       end
 
-      context "when signed_assertion_opts is true" do
+      context "non when signed_assertion_opts is false" do
         it "builds a signed assertion" do
           expect { subject.build }.not_to raise_error
           signed_encoded_xml = subject.build
@@ -127,8 +127,8 @@ module SamlIdp
         end
       end
 
-      context "when signed_assertion_opts is false" do
-        let(:signed_assertion_opts) { false }
+      context "when non signed_assertion_opts is true" do
+        let(:non_signed_assertion_opts) { true }
 
         it "builds a raw assertion" do
           expect { subject.build }.not_to raise_error


### PR DESCRIPTION
According to SAML specifications assertions _may_ be signed.

This PR allows to add raw assertions on responses.
I branched from [signed_response_message](https://github.com/Zogoo/saml_idp/tree/signed_response_message) which has an updated README about signing responses and assertions 