### PR TITLE
[feat] Allow SP config force signature validation

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -130,11 +130,8 @@ module SamlIdp
       # Force signatures for logout requests because there is no other protection against a cross-site DoS.
       # Validate signature when metadata specify AuthnRequest should be signed
       metadata = service_provider.current_metadata
-      if logout_request? || authn_request? && metadata.respond_to?(:sign_authn_request?) && metadata.sign_authn_request?
-        document.valid_signature?(service_provider.cert, service_provider.fingerprint)
-      else
-        true
-      end
+      require_signature = logout_request? || authn_request? && metadata.respond_to?(:sign_authn_request?) && metadata.sign_authn_request?
+      service_provider.valid_signature?(document, require_signature)
     end
 
     def valid_external_signature?

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -128,13 +128,16 @@ module SamlIdp
 
     def valid_signature?
       # Force signatures for logout requests because there is no other protection against a cross-site DoS.
-      # Validate signature when metadata specify AuthnRequest should be signed
-      metadata = service_provider.current_metadata
-      require_signature = logout_request? || authn_request? && metadata.respond_to?(:sign_authn_request?) && metadata.sign_authn_request?
-      service_provider.valid_signature?(document, require_signature)
+      if logout_request? || authn_request? && validate_auth_request_signature?
+        document.valid_signature?(service_provider.cert, service_provider.fingerprint)
+      else
+        true
+      end
     end
 
     def valid_external_signature?
+      return true if authn_request? && !validate_auth_request_signature?
+
       cert = OpenSSL::X509::Certificate.new(service_provider.cert)
 
       sha_version = sig_algorithm =~ /sha(.*?)$/i && $1.to_i
@@ -229,5 +232,14 @@ module SamlIdp
       config.service_provider.finder
     end
     private :service_provider_finder
+
+    def validate_auth_request_signature?
+      # Validate signature when metadata specify AuthnRequest should be signed
+      metadata = service_provider.current_metadata
+      sign_authn_request = metadata.respond_to?(:sign_authn_request?) && metadata.sign_authn_request?
+      sign_authn_request = service_provider.sign_authn_request unless service_provider.sign_authn_request.nil? 
+      sign_authn_request
+    end
+    private :validate_auth_request_signature?
   end
 end

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -11,6 +11,7 @@ module SamlIdp
     attribute :fingerprint
     attribute :metadata_url
     attribute :validate_signature
+    attribute :sign_authn_request
     attribute :acs_url
     attribute :assertion_consumer_logout_service_url
     attribute :response_hosts
@@ -23,7 +24,7 @@ module SamlIdp
 
     def valid_signature?(doc, require_signature = false)
       if require_signature || attributes[:validate_signature]
-        doc.valid_signature?(cert, fingerprint)
+        doc.valid_signature?(fingerprint)
       else
         true
       end

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -23,7 +23,7 @@ module SamlIdp
 
     def valid_signature?(doc, require_signature = false)
       if require_signature || attributes[:validate_signature]
-        doc.valid_signature?(fingerprint)
+        doc.valid_signature?(cert, fingerprint)
       else
         true
       end

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -128,7 +128,7 @@ describe SamlIdp::Controller do
   context "Single Logout Request" do
     before do
       idp_configure("https://foo.example.com/saml/consume", true)
-      slo_request = make_saml_sp_slo_request
+      slo_request = make_saml_sp_slo_request(security_options: { embed_sign: false })
       params[:SAMLRequest] = slo_request['SAMLRequest']
       params[:RelayState] = slo_request['RelayState']
       params[:SigAlg] = slo_request['SigAlg']

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -18,10 +18,9 @@ module SamlRequestMacros
     Base64.strict_encode64(request_builder.signed)
   end
 
-  def make_saml_sp_slo_request(param_type: true, embed_sign: false)
+  def make_saml_sp_slo_request(param_type: true, security_options: {})
     logout_request = OneLogin::RubySaml::Logoutrequest.new
-    saml_sp_setting = saml_settings("https://foo.example.com/saml/consume")
-    add_securty_options(saml_sp_setting, embed_sign: embed_sign)
+    saml_sp_setting = saml_settings("https://foo.example.com/saml/consume", true, security_options: security_options)
     if param_type
       logout_request.create_params(saml_sp_setting, 'RelayState' => 'https://foo.example.com/home')
     else
@@ -34,7 +33,7 @@ module SamlRequestMacros
     sp_metadata.generate(saml_settings(saml_acs_url, enable_secure_options), true)
   end
 
-  def saml_settings(saml_acs_url = "https://foo.example.com/saml/consume", enable_secure_options = false)
+  def saml_settings(saml_acs_url = "https://foo.example.com/saml/consume", enable_secure_options = false, security_options: {})
     settings = OneLogin::RubySaml::Settings.new
     settings.assertion_consumer_service_url = saml_acs_url
     settings.issuer = "http://example.com/issuer"
@@ -43,28 +42,22 @@ module SamlRequestMacros
     settings.assertion_consumer_logout_service_url = 'https://foo.example.com/saml/logout'
     settings.idp_cert_fingerprint = SamlIdp::Default::FINGERPRINT
     settings.name_identifier_format = SamlIdp::Default::NAME_ID_FORMAT
-    add_securty_options(settings) if enable_secure_options
+    add_securty_options(settings, default_sp_security_options.merge!(security_options)) if enable_secure_options
     settings
   end
 
-  def add_securty_options(settings, authn_requests_signed: true, 
-                                    embed_sign: true, 
-                                    logout_requests_signed: true, 
-                                    logout_responses_signed: true,
-                                    digest_method: XMLSecurity::Document::SHA256,
-                                    signature_method: XMLSecurity::Document::RSA_SHA256,
-                                    assertions_signed: true)
+  def add_securty_options(settings, options = default_sp_security_options)
     # Security section
     settings.idp_cert = SamlIdp::Default::X509_CERTIFICATE
     # Signed embedded singature
-    settings.security[:authn_requests_signed] = authn_requests_signed
-    settings.security[:embed_sign] = embed_sign
-    settings.security[:logout_requests_signed] = logout_requests_signed
-    settings.security[:logout_responses_signed] = logout_responses_signed
-    settings.security[:metadata_signed] = digest_method
-    settings.security[:digest_method] = digest_method
-    settings.security[:signature_method] = signature_method
-    settings.security[:want_assertions_signed] = assertions_signed
+    settings.security[:authn_requests_signed] = options[:authn_requests_signed]
+    settings.security[:embed_sign] = options[:embed_sign]
+    settings.security[:logout_requests_signed] = options[:logout_requests_signed]
+    settings.security[:logout_responses_signed] = options[:logout_responses_signed]
+    settings.security[:metadata_signed] = options[:digest_method]
+    settings.security[:digest_method] = options[:digest_method]
+    settings.security[:signature_method] = options[:signature_method]
+    settings.security[:want_assertions_signed] = options[:assertions_signed]
     settings.private_key = sp_pv_key
     settings.certificate = sp_x509_cert
   end
@@ -108,5 +101,17 @@ module SamlRequestMacros
     outbuf = ""
     doc.write(outbuf, 1)
     puts outbuf
+  end
+
+  def default_sp_security_options
+    {
+      authn_requests_signed: true, 
+      embed_sign: true, 
+      logout_requests_signed: true, 
+      logout_responses_signed: true,
+      digest_method: XMLSecurity::Document::SHA256,
+      signature_method: XMLSecurity::Document::RSA_SHA256,
+      assertions_signed: true
+    }
   end
 end

--- a/spec/support/security_helpers.rb
+++ b/spec/support/security_helpers.rb
@@ -51,7 +51,7 @@ module SecurityHelpers
     @signature_fingerprint1 ||= "C5:19:85:D9:47:F1:BE:57:08:20:25:05:08:46:EB:27:F6:CA:B7:83"
   end
 
-  def signature_1
+  def certificate_1
     @signature1 ||= File.read(File.join(File.dirname(__FILE__), 'certificates', 'certificate1'))
   end
 


### PR DESCRIPTION
The service provider (SP) has a configuration parameter called "validate_signature" that is intended to enforce signature validation. However, this parameter was never utilized, which led to an issue where the SP configuration couldn't control the validation of authentication requests.

- [x] Test in real SP in dev env
