### PR TITLE
[feat] Don’t ignore certificates without usage

### DIFF
--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -65,7 +65,7 @@ module SamlIdp
 
     def unspecified_certificate
       xpath(
-        "//md:SPSSODescriptor/md:KeyDescriptor/ds:KeyInfo/ds:X509Data/ds:X509Certificate",
+        "//md:SPSSODescriptor/md:KeyDescriptor[not(@use)]/ds:KeyInfo/ds:X509Data/ds:X509Certificate",
         ds: signature_namespace,
         md: metadata_namespace
       ).first.try(:content).to_s

--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -63,6 +63,15 @@ module SamlIdp
     end
     hashable :contact_person
 
+    def unspecified_certificate
+      xpath(
+        "//md:SPSSODescriptor/md:KeyDescriptor/ds:KeyInfo/ds:X509Data/ds:X509Certificate",
+        ds: signature_namespace,
+        md: metadata_namespace
+      ).first.try(:content).to_s
+    end
+    hashable :unspecified_certificate
+
     def signing_certificate
       xpath(
         "//md:SPSSODescriptor/md:KeyDescriptor[@use='signing']/ds:KeyInfo/ds:X509Data/ds:X509Certificate",

--- a/spec/lib/saml_idp/incoming_metadata_spec.rb
+++ b/spec/lib/saml_idp/incoming_metadata_spec.rb
@@ -109,9 +109,10 @@ module SamlIdp
       expect(metadata.unspecified_certificate).to eq('')
     end
 
-    it 'should properly set signing_certificate when present' do
+    it 'should properly set signing_certificate when present but not unspecified_certificate' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_6)
       expect(metadata.signing_certificate).to eq('MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmw6vGr...')
+      expect(metadata.unspecified_certificate).to eq('')
     end
 
     it 'should return empty signing_certificate when not present' do
@@ -119,9 +120,10 @@ module SamlIdp
       expect(metadata.signing_certificate).to eq('')
     end
 
-    it 'should properly set encryption_certificate when present' do
+    it 'should properly set encryption_certificate when present but not unspecified_certificate' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_7)
       expect(metadata.encryption_certificate).to eq('MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1dX3Gr...')
+      expect(metadata.unspecified_certificate).to eq('')
     end
 
     it 'should return empty encryption_certificate when not present' do

--- a/spec/lib/saml_idp/incoming_metadata_spec.rb
+++ b/spec/lib/saml_idp/incoming_metadata_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+
 module SamlIdp
 
   metadata_1 = <<-eos
@@ -29,6 +30,48 @@ module SamlIdp
 </md:EntityDescriptor>
   eos
 
+  metadata_5 = <<-eos
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="test" entityID="https://test-saml.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor>
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnht3GR...</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>
+  eos
+
+  metadata_6 = <<-eos
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="test" entityID="https://test-saml.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmw6vGr...</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>
+  eos
+
+  metadata_7 = <<-eos
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="test" entityID="https://test-saml.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1dX3Gr...</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>
+  eos
+
   describe IncomingMetadata do
     it 'should properly set sign_assertions to false' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_1)
@@ -54,6 +97,36 @@ module SamlIdp
     it 'should properly set sign_authn_request to false when AuthnRequestsSigned is not included' do
       metadata = SamlIdp::IncomingMetadata.new(metadata_4)
       expect(metadata.sign_authn_request).to eq(false)
+    end
+
+    it 'should properly set unspecified_certificate when present' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_5)
+      expect(metadata.unspecified_certificate).to eq('MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnht3GR...')
+    end
+
+    it 'should return empty unspecified_certificate when not present' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_1)
+      expect(metadata.unspecified_certificate).to eq('')
+    end
+
+    it 'should properly set signing_certificate when present' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_6)
+      expect(metadata.signing_certificate).to eq('MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmw6vGr...')
+    end
+
+    it 'should return empty signing_certificate when not present' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_1)
+      expect(metadata.signing_certificate).to eq('')
+    end
+
+    it 'should properly set encryption_certificate when present' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_7)
+      expect(metadata.encryption_certificate).to eq('MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1dX3Gr...')
+    end
+
+    it 'should return empty encryption_certificate when not present' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_1)
+      expect(metadata.encryption_certificate).to eq('')
     end
   end
 end


### PR DESCRIPTION
Official SAML 2.0 specification says it's an optional value, but if immediately follows this behavior some of SP might not work with the gem. Hence we need to leave the decision to the application.
> use [Optional]
> Optional attribute specifying the purpose of the key being described. Values are drawn from the
> KeyTypes enumeration, and consists of the values encryption and signing.