### PR TITLE
[feat] Support lowercase percent-encoded URL for signature validation

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -151,7 +151,11 @@ module SamlIdp
         OpenSSL::Digest::SHA1
       end
 
-      cert.public_key.verify(signature_algorithm.new, raw_signature, query_request_string)
+      result = cert.public_key.verify(signature_algorithm.new, raw_signature, query_request_string)
+      # Match all percent-encoded sequences (e.g., %20, %2B) and convert them to lowercase
+      # Upper case is recommended for consistency but some services such as MS Entra Id not follows it
+      # https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
+      result || cert.public_key.verify(signature_algorithm.new, raw_signature, query_request_string.gsub(/%[A-F0-9]{2}/) { |match| match.downcase })
     end
 
     def service_provider?


### PR DESCRIPTION
Specification suggested the use of UPPERCASE encoding for consistency. 
But some services do not follow them https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 and this reason signature verification was failing.
For example: MS Entra ID's SLO request uses lowercase for external signature parameters.