### PR TITLE
concurrent-ruby v1.3.5 has removed the dependency on logger

### DIFF
--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.2.4"
 gem "activeresource", "~> 5.1.0"
+gem 'concurrent-ruby', '1.3.4'
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
 gem "activeresource", "~> 5.1.0"
+gem 'concurrent-ruby', '1.3.4'
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
 gem "activeresource", "~> 6.0.0"
+gem 'concurrent-ruby', '1.3.4'
 
 gemspec path: "../"


### PR DESCRIPTION
Origin: https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror