### PR TITLE
Add SLO request builde into Controller helper

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -4,6 +4,8 @@ require 'time'
 require 'securerandom'
 require 'saml_idp/request'
 require 'saml_idp/logout_response_builder'
+require 'saml_idp/logout_request_builder'
+
 module SamlIdp
   module Controller
     extend ActiveSupport::Concern


### PR DESCRIPTION
One of the required features is the SLO request from IdP. However, the "SamlIdp::LogoutRequestBuilder" class was not found in the controller.

```ruby
dummy(dev)> SamlIdp::LogoutRequestBuilder
(dummy):2:in '<top (required)>': uninitialized constant SamlIdp::LogoutRequestBuilder (NameError)
Did you mean?  SamlIdp::LogoutResponseBuilder
```